### PR TITLE
Add bentoml dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ultralytics>=8.1
+bentoml>=1.2.7


### PR DESCRIPTION
We will ask users to use the requirements.txt file to install all the dependencies, so `bentoml` needs to be added.