### PR TITLE
update system packages names

### DIFF
--- a/service.py
+++ b/service.py
@@ -11,7 +11,7 @@ from bentoml.validators import ContentType
 Image = t.Annotated[Path, ContentType("image/*")]
 
 image = bentoml.images.Image(python_version='3.11', lock_python_packages=False) \
-    .system_packages('libglib2.0-0', 'libsm6', 'libxext6', 'libxrender1', 'libgl1-mesa-glx') \
+    .system_packages('libglib2.0-0t64', 'libsm6', 'libxext6', 'libxrender1', 'libgl1-mesa-dri') \
     .requirements_file('requirements.txt')
 
 @bentoml.service(resources={"gpu": 1}, image=image)


### PR DESCRIPTION
Update the list of system packages in  service.py  to stay compatible with Debian trixie (and recent  python:3.11-slim  images):
 libglib2.0-0  →  libglib2.0-0t64 
drop removed  libgl1-mesa-glx ; keep  libgl1-mesa-dri  for Mesa software rasterizer
This fixes the "Package 'libgl1-mesa-glx' has no installation candidate"  error when building the Bento on current base images.