### PR TITLE
fix: add missing libGL.so.1 for OpenCV in container

### DIFF
--- a/service.py
+++ b/service.py
@@ -11,7 +11,7 @@ from bentoml.validators import ContentType
 Image = t.Annotated[Path, ContentType("image/*")]
 
 image = bentoml.images.Image(python_version='3.11', lock_python_packages=False) \
-    .system_packages('libglib2.0-0t64', 'libsm6', 'libxext6', 'libxrender1', 'libgl1-mesa-dri') \
+    .system_packages('libgl1','libglx-mesa0','libglib2.0-0t64', 'libsm6', 'libxext6', 'libxrender1', 'libgl1-mesa-dri') \
     .requirements_file('requirements.txt')
 
 @bentoml.service(resources={"gpu": 1}, image=image)


### PR DESCRIPTION
Container fails at runtime with
```
ImportError: libGL.so.1: cannot open shared object file: No such file or directory

```
because  cv2  (pulled in via  ultralytics ) needs a GL dispatch library which is not shipped by the slim Debian base image.
added  libgl1  and  libglx-mesa0  to  system_packages in 'service.py'.